### PR TITLE
chore(release): 0.31.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.31.3](https://github.com/bryanforbes/asyncpg-stubs/compare/v0.31.2..v0.31.3) - 2026-07-09
+
+### Bug Fixes
+
+- use `Generator` for context managers ([8cb4973](https://github.com/bryanforbes/asyncpg-stubs/commit/8cb4973c1922b096f828c8aebfd2d2f1a53d9864))
+- annotate pool reset parameter as `Awaitable[None]` ([#431](https://github.com/bryanforbes/asyncpg-stubs/pull/431)
+
 ## [0.31.2](https://github.com/bryanforbes/asyncpg-stubs/compare/v0.31.1..v0.31.2) - 2026-02-19
 
 ### Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "asyncpg-stubs"
-version = "0.31.3.dev0"
+version = "0.31.3"
 description = "asyncpg stubs"
 authors = [
   {name = "Bryan Forbes", email = "bryan@reigndropsfall.net"},


### PR DESCRIPTION
### Bug Fixes

- use `Generator` for context managers ([8cb4973](https://github.com/bryanforbes/asyncpg-stubs/commit/8cb4973c1922b096f828c8aebfd2d2f1a53d9864))
- annotate pool reset parameter as `Awaitable[None]` ([81479fd](https://github.com/bryanforbes/asyncpg-stubs/commit/81479fdb063953728630eb5611d5ea793f0779bb))

